### PR TITLE
Bug fixes for experiment init and emailing users

### DIFF
--- a/bin/globus
+++ b/bin/globus
@@ -148,9 +148,17 @@ def main():
 
     args = config.parse_known_args(parser, subparser=True)
   
-    
+    #Do config here, because otherwise we won't have PVs to update our info anyway
+    if args._func == set_config:
+        try:
+            args._func(args)
+            return
+        except RuntimeError as e:
+            log.error(str(e))
+            sys.exit(1)
+        return
+
     #Init here, otherwise we don't have parameters to do the following updates
-    
     args.year_month, args.pi_last_name, args.gup_number, args.gup_title = pv.update_experiment_info(args)
 
     if args._func == init:
@@ -160,7 +168,8 @@ def main():
         except RuntimeError as e:
             log.error(str(e))
             sys.exit(1)
-         
+        return 
+
     args.year_month, args.pi_last_name, args.gup_number, args.gup_title = pv.update_experiment_info(args)
 
     if (args.globus_server_name == 'voyager'):

--- a/globus/message-7bm-nontomo.txt
+++ b/globus/message-7bm-nontomo.txt
@@ -1,0 +1,14 @@
+This is an automated message with important information about your experiment.  Your data will be automatically transferred to Voyager, one of the main APS data storage systems.  The transfer will occur from the data analysis computer (mach), so any test reconstructions you do at the beamline should also be backed up to Voyager.  Please note that this message was automatically sent to all users on the proposal.  If other users not on the proposal (for example, students or collaborators) should have this information, please forward it to them.
+
+Your data on Voyager can be accessed through Globus Online, a grid FTP system.  Please go to the link below, or to https://www.globus.org and log in using your Globus credentials.  Voyager is accessed through the aps#data endpoint.  Your credentials for Voyager are your badge number prepended with a 'd' (for example, for badge number 123456, it would be d123456), with the same password as you use for the GUP and ESAF systems.  If you wish to have other APS users given access to these data (for example, students that were involved in an experiment who weren't on the original proposal), please let Alan know so he can add them as authorized users.
+
+Data link: 
+
+Please download and make a copy of the data (raw with a backup) within 4 weeks. After that time the data will be subject to deletion from our systems.  If you need more time please send an email to Alan at akastengren@anl.gov.
+
+For beamline documentation and support requests:
+https://docs7bm.readthedocs.io/
+
+Remember to send references to any papers written using data from APS to Alan at akastengren@anl.gov for inclusion in the APS Publications database.  Information on the database and the required acknowledgement statement for the use of APS can be found at https://www.aps.anl.gov/Science/Publications .
+=======
+The 7-BM Team

--- a/globus/message.py
+++ b/globus/message.py
@@ -49,7 +49,7 @@ def send_email(args):
     emails.append(args.secondary_beamline_contact_email)
 
     if (args.globus_server_name == 'voyager'):
-        s = smtplib.SMTP('localhost')
+        s = smtplib.SMTP('mailhost.anl.gov')
         for em in emails:
             if args.msg['To'] is None:
                 args.msg['To'] = em


### PR DESCRIPTION
There was a bug where an exception would be thrown when initializing an experiment.  Also, after updating the beamline workstations, I was having problems with the functionality to email users a Globus link.  Jeff Hoffman from APS IT provided a solution for the email bug.